### PR TITLE
Upgrade to 7.4.2 for ElasticSearch and Kibana.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Please note: in this example Fluentd will run on port `8080` instead of the defa
 
 This settings has been changed to show how to configure Fluentd to listen on a different port.
 
+Kibana is exposed on port `5601`.
+
 ### Testing with sample data
 
 If you are running macOS and you want to send sample data to test the EFK stack, you'll need [RESTed][rested].

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.2
     environment:
       discovery.type: single-node
     ports:
@@ -17,7 +17,7 @@ services:
       - 8080:8080
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:6.2.4
+    image: docker.elastic.co/kibana/kibana:7.4.2
     environment:
       ELASTICSEARCH_URL: http://elasticsearch:9200
     ports:


### PR DESCRIPTION
Simple PR to upgrade dependencies :
- ElasticSearch and Kibana version from `6.2.4` to `7.4.2`
- Clarify `README.md` a little by specifying the exposed port for Kibana without having to look at the `docker-compose` file.